### PR TITLE
Bugfix - $category->setTranslation('name', 'en', 'My New Category BugFix')->save();

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ $category = Category::find(1);
 $category->setTranslation('name', 'en', 'Name in English');
 
 // Get category translation
-$category->setTranslation('name', 'en');
+$category->getTranslation('name', 'en');
 
 // Get category name in default locale
 $category->name;

--- a/src/Category.php
+++ b/src/Category.php
@@ -157,30 +157,6 @@ class Category extends Model
     }
 
     /**
-     * Set the translatable name attribute.
-     *
-     * @param string $value
-     *
-     * @return void
-     */
-    public function setNameAttribute($value)
-    {
-        $this->attributes['name'] = json_encode(! is_array($value) ? [app()->getLocale() => $value] : $value);
-    }
-
-    /**
-     * Set the translatable description attribute.
-     *
-     * @param string $value
-     *
-     * @return void
-     */
-    public function setDescriptionAttribute($value)
-    {
-        $this->attributes['description'] = ! empty($value) ? json_encode(! is_array($value) ? [app()->getLocale() => $value] : $value) : null;
-    }
-
-    /**
      * Enforce clean slugs.
      *
      * @param string $value


### PR DESCRIPTION
Meine default-Sprache ist deutsch (de).
Fogender Code funktioniert nicht:

```
$category = Category::createByName('Meine neue Kategorie BugFix');
$category->setTranslation('name', 'en', 'My New Category BugFix')->save();
```

Ich nutze nun die spatie/laravel-translatable Bibliothek aus und habe die Accessoren entfernt. Die spatie/laravel-translatable Bibliothek hat dafür bereits ein Workaround, warum das Rad neu erfinden? :-)

### Vorher:
![2017-03-29 19_35_19-admin-panel - c__xampp_htdocs_admin-panel - _app_http_controllers_frontend_](https://cloud.githubusercontent.com/assets/4435288/24468955/2ca337f0-14ba-11e7-8c79-8f7160324c53.png)
![2017-03-29 19_31_54-unnamed_admin_panel_categories_ - heidisql 9 4 0 5143](https://cloud.githubusercontent.com/assets/4435288/24468922/126acaba-14ba-11e7-95bd-139156a9aee6.png)

### Nachher:
![2017-03-29 19_35_58-admin-panel - c__xampp_htdocs_admin-panel - _app_http_controllers_frontend_](https://cloud.githubusercontent.com/assets/4435288/24469010/55f92da8-14ba-11e7-895d-8a35bfba0f4f.png)
![2017-03-29 19_34_16-unnamed_admin_panel_categories_ - heidisql 9 4 0 5143](https://cloud.githubusercontent.com/assets/4435288/24469001/4d7010ca-14ba-11e7-954e-b815b07b93a7.png)

### README:
Einen minimalen Fehler bei der Beschreibung innerhalb der README entfernt.